### PR TITLE
Conflicting AbortController after upgrade

### DIFF
--- a/tools/denolib.ts
+++ b/tools/denolib.ts
@@ -19,9 +19,10 @@ declare class AbortController {
   /** Returns the AbortSignal object associated with this object. */
   readonly signal: AbortSignal;
   /** Invoking this method will set this object's AbortSignal's aborted flag and
-    * signal to any observers that the associated activity is to be aborted. */
+   * signal to any observers that the associated activity is to be aborted. */
   abort(): void;
 }
+
 `,
     "",
   ),


### PR DESCRIPTION
Ref: https://github.com/denoland/deno.ns/issues/14

Run `npm run denolib` to generate your lib.deno.d.ts, then run `npm run build`. I see no new errors during build. The only error I got was this conflicting AbortController definition, which this commit fixes.

Signed-off-by: Muthu Kumar <muthukumar@thefeathers.in>