### PR TITLE
fix: Deno.ppid & Deno.sleepSync

### DIFF
--- a/src/deno/stable/functions.ts
+++ b/src/deno/stable/functions.ts
@@ -58,7 +58,6 @@ export { removeSync } from "./functions/removeSync.js";
 export { rename } from "./functions/rename.js";
 export { renameSync } from "./functions/renameSync.js";
 export { shutdown } from "./functions/shutdown.js";
-export { sleepSync } from "./functions/sleepSync.js";
 export { stat } from "./functions/stat.js";
 export { statSync } from "./functions/statSync.js";
 export { symlink } from "./functions/symlink.js";

--- a/src/deno/stable/functions/sleepSync.ts
+++ b/src/deno/stable/functions/sleepSync.ts
@@ -1,6 +1,7 @@
 ///<reference path="../lib.deno.d.ts" />
 
-// @ts-expect-error sleepSync is documented as unstable but available in stable
+// This file is not exported in functions.ts; we must come back when sleepSync is stable
+// @ts-expect-error sleepSync was previously documented as unstable but available in stable
 export const sleepSync: Deno.sleepSync = function sleepSync(millis: number) {
   // buffer will never change to awaited value,
   // Atomics will block the thread for given milliseconds and return

--- a/src/deno/stable/variables/ppid.ts
+++ b/src/deno/stable/variables/ppid.ts
@@ -1,4 +1,3 @@
 ///<reference path="../lib.deno.d.ts" />
 
-// @ts-expect-error ppid is documented as unstable but available in stable
-export const ppid: Deno.ppid = process.ppid;
+export const ppid: typeof Deno.ppid = process.ppid;


### PR DESCRIPTION
Resolves #14.

The underlying problem was from https://github.com/denoland/deno/issues/10827. Because there was a type vs implementation disparity upstream, we had imitated it in deno.ns. Since upstream is fixed, ppid is now stable, and sleepSync is unstable. I've removed the import for sleepSync in this PR. We can add it back if/when upstream sleepSync is stable, or remove it if Deno does too.

I tried to add support for unstable imports, but this breaks because stable and unstable `lib.deno.d.ts` cause conflicts. This is in a branch if you want to check it out: https://github.com/MKRhere/deno.ns/tree/feat-unstable-deno, and I'm not sure if/how to tackle this yet. We can discuss this in a different issue if we evaluate that unstable is necessary.

Signed-off-by: Muthu Kumar <muthukumar@thefeathers.in>