### PR TITLE
Write version along with denolib

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "src/deno/stable/lib.deno.d.ts"
   ],
   "scripts": {
-    "denolib": "deno run --allow-run --allow-write=src/deno/stable/lib.deno.d.ts tools/denolib.ts",
+    "denolib": "deno run --allow-run --allow-write=src/deno/ tools/denolib.ts",
     "build": "tsc",
     "prepare": "npm run --silent denolib && npm run --silent build",
     "lint": "deno lint --ignore=node_modules,dist,thirdparty,unit,src/deno/stable/lib.deno.d.ts",

--- a/src/deno/internal/version.ts
+++ b/src/deno/internal/version.ts
@@ -1,0 +1,2 @@
+export const deno = "1.14.3";
+export const typescript = "4.4.2";

--- a/src/deno/stable/variables/version.ts
+++ b/src/deno/stable/variables/version.ts
@@ -1,7 +1,9 @@
 ///<reference path="../lib.deno.d.ts" />
 
+import { deno, typescript } from "../../internal/version.js";
+
 export const version: typeof Deno.version = {
-  deno: "1.13.0",
-  typescript: "4.3.5",
+  deno,
+  typescript,
   v8: process.versions.v8,
 };

--- a/tools/denolib.ts
+++ b/tools/denolib.ts
@@ -3,11 +3,28 @@ if (!Deno.version.deno.startsWith("1.14")) {
   Deno.exit(1);
 }
 
-const out = new TextDecoder().decode(
-  await Deno.run({
-    cmd: ["deno", "types"],
-    stdout: "piped",
-  }).output(),
+const run = async (cmd: string) =>
+  new TextDecoder().decode(
+    await Deno.run({
+      cmd: cmd.split(" "),
+      stdout: "piped",
+    }).output(),
+  );
+
+const out = await run("deno types");
+const version = (await run("deno --version")).trim().split("\n").map((line) =>
+  line.split(" ")
+).reduce(
+  (acc, curr) => ({ ...acc, [curr[0]]: curr[1] }),
+  {} as { [k: string]: string },
+);
+
+await Deno.writeTextFile(
+  "src/deno/internal/version.ts",
+  [
+    `export const deno = "${version.deno}";\n`,
+    `export const typescript = "${version.typescript}";\n`,
+  ].join(""),
 );
 
 await Deno.writeTextFile(


### PR DESCRIPTION
`npm run denolib` will now write the current version along with lib.deno.d.ts

Signed-off-by: Muthu Kumar <muthukumar@thefeathers.in>