### PR TITLE
chore: update ci branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
The master branch seems renamed to main branch and CI is not running on main now. This PR tries to fix it.