### PR TITLE
Make `@fromdeno/test` optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
   "engines": {
     "node": ">=16.7.0"
   },
+  "peerDependenciesMeta": {
+    "@fromdeno/test": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "undici": "^4.5.1"
   },

--- a/src/deno/stable/functions/test.ts
+++ b/src/deno/stable/functions/test.ts
@@ -1,6 +1,13 @@
 ///<reference path="../lib.deno.d.ts" />
 
-export { test } from "@fromdeno/test";
+export let test: typeof Deno.test;
+
+try {
+  test = require("@fromdeno/test").test;
+} catch {
+  test = () => {};
+}
+
 import type { AssertTrue, IsExact } from "conditional-type-checks";
 type _TypeTest = AssertTrue<
   IsExact<typeof import("@fromdeno/test").test, typeof Deno.test>


### PR DESCRIPTION
> `@fromdeno/test` could be turned into an optional peer dependency. When unavailable (`npm install --production`), `Deno.test` would be no-op. https://github.com/denoland/deno.ns/pull/25#issuecomment-944906561

Closes #25.