### PR TITLE
fix: restore errors namespace in declaration file

### DIFF
--- a/lib/deno.ns.lib.d.ts
+++ b/lib/deno.ns.lib.d.ts
@@ -2455,58 +2455,60 @@ export declare namespace Deno {
         toObject(): { [index: string]: string };
       };
 
-  export class AddrInUse extends Error {
-  }
+  export namespace errors {
+    export class AddrInUse extends Error {
+    }
 
-  export class AddrNotAvailable extends Error {
-  }
+    export class AddrNotAvailable extends Error {
+    }
 
-  export class AlreadyExists extends Error {
-  }
+    export class AlreadyExists extends Error {
+    }
 
-  export class BadResource extends Error {
-  }
+    export class BadResource extends Error {
+    }
 
-  export class BrokenPipe extends Error {
-  }
+    export class BrokenPipe extends Error {
+    }
 
-  export class Busy extends Error {
-  }
+    export class Busy extends Error {
+    }
 
-  export class ConnectionAborted extends Error {
-  }
+    export class ConnectionAborted extends Error {
+    }
 
-  export class ConnectionRefused extends Error {
-  }
+    export class ConnectionRefused extends Error {
+    }
 
-  export class ConnectionReset extends Error {
-  }
+    export class ConnectionReset extends Error {
+    }
 
-  export class Http extends Error {
-  }
+    export class Http extends Error {
+    }
 
-  export class Interrupted extends Error {
-  }
+    export class Interrupted extends Error {
+    }
 
-  export class InvalidData extends Error {
-  }
+    export class InvalidData extends Error {
+    }
 
-  export class NotConnected extends Error {
-  }
+    export class NotConnected extends Error {
+    }
 
-  export class NotFound extends Error {
-  }
+    export class NotFound extends Error {
+    }
 
-  export class PermissionDenied extends Error {
-  }
+    export class PermissionDenied extends Error {
+    }
 
-  export class TimedOut extends Error {
-  }
+    export class TimedOut extends Error {
+    }
 
-  export class UnexpectedEof extends Error {
-  }
+    export class UnexpectedEof extends Error {
+    }
 
-  export class WriteZero extends Error {
+    export class WriteZero extends Error {
+    }
   }
 
   /** The URL of the entrypoint module entered from the command-line. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deno.ns",
-  "version": "0.6.2",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "deno.ns",
-      "version": "0.6.2",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "undici": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deno.ns",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Deno namespace shim for Node.js",
   "keywords": [
     "deno namespace",


### PR DESCRIPTION
Restores the `errors` namespace in the declaration file.

I accidentally removed it in the last PR that generated the declaration file.