### PR TITLE
fix(types): fix constructor types for global fallback types

### DIFF
--- a/lib/deno.ns.lib.d.ts
+++ b/lib/deno.ns.lib.d.ts
@@ -163,39 +163,25 @@ declare type EventListenerOrEventListenerObject = | EventListener
     | EventListenerObject;
 export { Blob } from "buffer";
 export { webcrypto as crypto } from "crypto";
-export declare const fetch: (typeof globalThis) extends {
-      "fetch": infer T;
-  } ? T : typeof undici.fetch;
-export declare type File = (typeof globalThis) extends {
-      "File": {
+declare type GlobalThisPrototypeType<TKey extends string, FallbackType> = (typeof globalThis) extends {
+      [P in TKey]: {
           prototype: infer T;
       };
-  } ? T : undici.File;
-export declare const File: File;
-export declare type FormData = (typeof globalThis) extends {
-      "FormData": {
-          prototype: infer T;
-      };
-  } ? T : undici.FormData;
-export declare const FormData: FormData;
-export declare type Headers = (typeof globalThis) extends {
-      "Headers": {
-          prototype: infer T;
-      };
-  } ? T : undici.Headers;
-export declare const Headers: Headers;
-export declare type Request = (typeof globalThis) extends {
-      "Request": {
-          prototype: infer T;
-      };
-  } ? T : undici.Request;
-export declare const Request: Request;
-export declare type Response = (typeof globalThis) extends {
-      "Response": {
-          prototype: infer T;
-      };
-  } ? T : undici.Response;
-export declare const Response: Response;
+  } ? T : FallbackType;
+declare type GlobalThisType<TKey extends string, FallbackType> = (typeof globalThis) extends {
+      [P in TKey]: infer T;
+  } ? T : FallbackType;
+export declare const fetch: GlobalThisType<"fetch", typeof undici.fetch>;
+export declare type File = GlobalThisPrototypeType<"File", undici.File>;
+export declare const File: GlobalThisType<"File", typeof undici.File>;
+export declare type FormData = GlobalThisPrototypeType<"FormData", undici.FormData>;
+export declare const FormData: GlobalThisType<"FormData", typeof undici.FormData>;
+export declare type Headers = GlobalThisPrototypeType<"Headers", undici.Headers>;
+export declare const Headers: GlobalThisType<"Headers", typeof undici.Headers>;
+export declare type Request = GlobalThisPrototypeType<"Request", undici.Request>;
+export declare const Request: GlobalThisType<"Request", typeof undici.Request>;
+export declare type Response = GlobalThisPrototypeType<"Response", undici.Response>;
+export declare const Response: GlobalThisType<"Response", typeof undici.Response>;
 export declare function setTimeout(cb: (...args: any[]) => void, delay?: number, ...args: any[]): number;
 export declare function setInterval(cb: (...args: any[]) => void, delay?: number, ...args: any[]): number;
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deno.ns",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "deno.ns",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "undici": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deno.ns",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Deno namespace shim for Node.js",
   "keywords": [
     "deno namespace",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,35 +7,43 @@ export * from "./util/mod.js";
 import * as undici from "undici";
 
 // fallback to using the global types and values if they exist
-export const fetch: (typeof globalThis) extends { "fetch": infer T } ? T
-  : typeof undici.fetch = (globalThis as any)["fetch"] ??
+
+/** @removeExportKeyword */
+export type GlobalThisPrototypeType<TKey extends string, FallbackType> =
+  (typeof globalThis) extends {
+    [P in TKey]: {
+      prototype: infer T;
+    };
+  } ? T
+    : FallbackType;
+
+/** @removeExportKeyword */
+export type GlobalThisType<TKey extends string, FallbackType> =
+  (typeof globalThis) extends {
+    [P in TKey]: infer T;
+  } ? T
+    : FallbackType;
+
+export const fetch: GlobalThisType<"fetch", typeof undici.fetch> =
+  (globalThis as any)["fetch"] ??
     undici.fetch;
 
-export type File = (typeof globalThis) extends
-  { "File": { prototype: infer T } } ? T
-  : undici.File;
-export const File: File = (globalThis as any)["File"] ?? undici.File;
+export type File = GlobalThisPrototypeType<"File", undici.File>;
+export const File: GlobalThisType<"File", typeof undici.File> =
+  (globalThis as any)["File"] ?? undici.File;
 
-export type FormData = (typeof globalThis) extends
-  { "FormData": { prototype: infer T } } ? T
-  : undici.FormData;
-export const FormData: FormData = (globalThis as any)["FormData"] ??
-  undici.FormData;
+export type FormData = GlobalThisPrototypeType<"FormData", undici.FormData>;
+export const FormData: GlobalThisType<"FormData", typeof undici.FormData> =
+  (globalThis as any)["FormData"] ?? undici.FormData;
 
-export type Headers = (typeof globalThis) extends
-  { "Headers": { prototype: infer T } } ? T
-  : undici.Headers;
-export const Headers: Headers = (globalThis as any)["Headers"] ??
-  undici.Headers;
+export type Headers = GlobalThisPrototypeType<"Headers", undici.Headers>;
+export const Headers: GlobalThisType<"Headers", typeof undici.Headers> =
+  (globalThis as any)["Headers"] ?? undici.Headers;
 
-export type Request = (typeof globalThis) extends
-  { "Request": { prototype: infer T } } ? T
-  : undici.Request;
-export const Request: Request = (globalThis as any)["Request"] ??
-  undici.Request;
+export type Request = GlobalThisPrototypeType<"Request", undici.Request>;
+export const Request: GlobalThisType<"Request", typeof undici.Request> =
+  (globalThis as any)["Request"] ?? undici.Request;
 
-export type Response = (typeof globalThis) extends
-  { "Response": { prototype: infer T } } ? T
-  : undici.Response;
-export const Response: Response = (globalThis as any)["Response"] ??
-  undici.Response;
+export type Response = GlobalThisPrototypeType<"Response", undici.Response>;
+export const Response: GlobalThisType<"Response", typeof undici.Response> =
+  (globalThis as any)["Response"] ?? undici.Response;

--- a/tools/generateDeclarationFile.ts
+++ b/tools/generateDeclarationFile.ts
@@ -165,9 +165,31 @@ function ensureExported<TStructure extends StatementStructures>(
   structure: TStructure,
 ) {
   if (Structure.isExportable(structure)) {
-    structure.isExported = true;
+    const isInternal = hasRemoveExportKeywordJsDocTag(structure);
+    structure.isExported = !isInternal;
+
+    // remove the jsdocs if its internal
+    if (isInternal && Structure.isJSDocable(structure)) {
+      delete structure.docs;
+    }
   }
   return structure;
+}
+
+function hasRemoveExportKeywordJsDocTag(structure: StatementStructures) {
+  if (!Structure.isJSDocable(structure)) {
+    return false;
+  }
+  if (!structure.docs || !(structure.docs instanceof Array)) {
+    return false;
+  }
+
+  return structure.docs.some((d) => {
+    if (!d || typeof d === "string") {
+      return false;
+    }
+    return d.tags?.some((t) => t.tagName === "removeExportKeyword") ?? false;
+  });
 }
 
 function stripAmbient<TStructure extends StatementStructures>(


### PR DESCRIPTION
I didn't exactly fix this last time around because it didn't work for constructor types (ex. `new Headers()`). It's hard to add unit tests for this, so I've tested it manually downstream.