### PR TITLE
feat: add `@deno/shim-timers` package

### DIFF
--- a/.vscode/project.code-workspace
+++ b/.vscode/project.code-workspace
@@ -15,6 +15,10 @@
 		{
 			"name": "third_party",
 			"path": "../packages/deno.ns/third_party"
+		},
+		{
+			"name": "shim-timers",
+			"path": "../packages/shim-timers"
 		}
 	],
 	"settings": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "deno.ns-workspace",
   "workspaces": [
-    "packages/deno.ns"
+    "packages/deno.ns",
+    "packages/shim-timers"
   ],
   "scripts": {
     "lint": "deno lint --config deno.json",

--- a/packages/deno.ns/src/util/mod.ts
+++ b/packages/deno.ns/src/util/mod.ts
@@ -33,29 +33,3 @@ export const prompt: typeof globalThis.prompt = globalThis["prompt"] ??
     const result = readlineSync();
     return result.length > 0 ? result : defaultValue ?? null;
   };
-
-const originalSetTimeout = globalThis.setTimeout;
-export function setTimeout(
-  cb: (...args: any[]) => void,
-  delay?: number,
-  ...args: any[]
-): number {
-  const result = originalSetTimeout(cb, delay, ...args);
-  // node may return a Timeout object, but return the primitive instead
-  return typeof result === "number"
-    ? result
-    : (result as any)[Symbol.toPrimitive]();
-}
-
-const originalSetInterval = globalThis.setInterval;
-export function setInterval(
-  cb: (...args: any[]) => void,
-  delay?: number,
-  ...args: any[]
-): number {
-  const result = originalSetInterval(cb, delay, ...args);
-  // node may return a Timeout object, but return the primitive instead
-  return typeof result === "number"
-    ? result
-    : (result as any)[Symbol.toPrimitive]();
-}

--- a/packages/shim-timers/LICENSE
+++ b/packages/shim-timers/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2021 the Deno authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/shim-timers/README.md
+++ b/packages/shim-timers/README.md
@@ -1,0 +1,4 @@
+# @deno/shim-timers
+
+Shims for `setTimeout` and `setInterval` that will work in the browser and
+Node.js.

--- a/packages/shim-timers/package.json
+++ b/packages/shim-timers/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@deno/shim-timers",
+  "version": "0.1.0",
+  "description": "Web compatible shim for setTimeout and setInterval.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "prepare": "echo \"Prepared.\"",
+    "build": "tsc",
+    "test": "echo \"No tests yet\""
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/denoland/deno.ns.git"
+  },
+  "keywords": [
+    "shim",
+    "deno",
+    "node.js",
+    "timers"
+  ],
+  "author": "The Deno authors",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/denoland/deno.ns/issues"
+  },
+  "homepage": "https://github.com/denoland/deno.ns#readme",
+  "devDependencies": {
+    "typescript": "^4.5.2"
+  }
+}

--- a/packages/shim-timers/src/index.ts
+++ b/packages/shim-timers/src/index.ts
@@ -1,0 +1,25 @@
+const originalSetTimeout = globalThis.setTimeout;
+export function setTimeout(
+  cb: (...args: any[]) => void,
+  delay?: number,
+  ...args: any[]
+): number {
+  const result = originalSetTimeout(cb, delay, ...args);
+  // node may return a Timeout object, but return the primitive instead
+  return typeof result === "number"
+    ? result
+    : (result as any)[Symbol.toPrimitive]();
+}
+
+const originalSetInterval = globalThis.setInterval;
+export function setInterval(
+  cb: (...args: any[]) => void,
+  delay?: number,
+  ...args: any[]
+): number {
+  const result = originalSetInterval(cb, delay, ...args);
+  // node may return a Timeout object, but return the primitive instead
+  return typeof result === "number"
+    ? result
+    : (result as any)[Symbol.toPrimitive]();
+}

--- a/packages/shim-timers/tsconfig.json
+++ b/packages/shim-timers/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "strict": true,
+    "target": "ES2019",
+    "lib": ["ES2019"],
+    "declaration": true,
+    "outDir": "dist",
+    "stripInternal": true
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true,
+    "compilerOptions": {
+      "module": "ES2015"
+    }
+  },
+  "files": ["src/index.ts"]
+}


### PR DESCRIPTION
Creates a `@deno/shim-timers` package that provides compatible `setTimeout` and `setInterval` functions.

This package will be used by dnt for shims for these two functions.